### PR TITLE
Track nested changes

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -36,7 +36,7 @@ export function getName(obj) {
 }
 
 /* eslint-disable no-param-reassign */
-export const setValue = mobx.action(function setValue(store, state) {
+function setValueAction(store, state) {
   store.__isRemotedevAction = true;
   if (store.importState) {
     store.importState(state);
@@ -46,5 +46,7 @@ export const setValue = mobx.action(function setValue(store, state) {
     });
   }
   delete store.__isRemotedevAction;
-});
+}
+setValueAction.__isRemotedevAction = true;
+export const setValue = mobx.action(setValueAction);
 /* eslint-enable */


### PR DESCRIPTION
As per #2 this enables tracking nested changes without explicitly wrapping them in `remotedev()`.

A few notes:

1. I'm not sure why the loop in `send()` was removed. I brought it back. It's used. I need feedback on this.
1. I'm not sure what
```
if (!onlyActions[objName]) {
  schedule(objName, { ...action, type: `┏ ${action.type}` });
  send();
  schedule(objName, { ...action, type: `┗ ${action.type}` });
```
was doing. I removed it. I need feedback on this. However to me this doesn't make sense.