### PR TITLE
[RFC] Track nested changes with full path

### DIFF
--- a/examples/simple-todo/index.js
+++ b/examples/simple-todo/index.js
@@ -19,7 +19,7 @@ var todoFactory = function (title) {
       finished: false
     }
   );
-  return remotedev(todo, { name: `Todo: ${title}` });
+  return todo;
 };
 
 var todoListFactory = function () {
@@ -41,7 +41,7 @@ var todoListFactory = function () {
     }
   });
 
-  return remotedev(todoList, { name: 'Todo list' });
+  return remotedev(todoList, { name: 'Todo list', onlyActions: true });
 };
 
 var TodoListView = mobxReact.observer(function TodoListView() {

--- a/src/utils.js
+++ b/src/utils.js
@@ -11,7 +11,11 @@ const getPayload = (change) => {
   };
 };
 
-export function createAction(name, change) {
+export function createAction(objName, objPath, change) {
+  let name;
+  if (objPath) name = `${objPath}.${objName}`;
+  else name = objName;
+
   if (!change) { // is action
     return { type: name };
   }


### PR DESCRIPTION
As discussed in #2 and #3 we want to track nested changes without explicitly wrapping them in `remotedev()`. In order to help debugging, to cancel (skip) actions and to autogenerates tests, we also want to add the path to the action name like following:

<img width="740" alt="screen shot 2016-08-02 at 9 54 33 pm" src="https://cloud.githubusercontent.com/assets/7957859/17341218/419318da-58fc-11e6-952c-4ed2e8b066a5.png">

This PR is still a proof of concept, it works only for arrays with `splice`. We need to handle other observable types and update types. There's a lot of work, so feedback would be welcome. Maybe we could get some information directly from MobX?
