### PR TITLE
Enable marking store as global, a.k.a - fallback for unknown changes.

### DIFF
--- a/src/spy.js
+++ b/src/spy.js
@@ -66,6 +66,10 @@ export default function spy(store, config) {
         schedule(objName);
         return;
       }
+      if (change.fn && change.fn.__isRemotedevAction) {
+        schedule(objName);
+        return;
+      }
       if (change.type === 'action') {
         const action = createAction(change.name);
         if (change.arguments && change.arguments.length) action.arguments = change.arguments;

--- a/src/spy.js
+++ b/src/spy.js
@@ -5,6 +5,7 @@ import { isFiltered } from './filters';
 import { dispatchMonitorAction } from './monitorActions';
 
 let isSpyEnabled = false;
+let fallbackStoreName;
 const stores = {};
 const onlyActions = {};
 const filters = {};
@@ -15,6 +16,10 @@ function configure(name, config = {}) {
   if (typeof config.onlyActions === 'undefined') onlyActions[name] = mobx.useStrict();
   else onlyActions[name] = config.onlyActions;
   if (config.filters) filters[name] = config.filters;
+  if (config.global) {
+    if (fallbackStoreName) throw Error("You've already defined a global store");
+    fallbackStoreName = name;
+  }
 }
 
 function init(store, config) {
@@ -56,6 +61,7 @@ export default function spy(store, config) {
         schedule(objName);
         return;
       }
+      if (!stores[objName]) objName = fallbackStoreName;
       if (!stores[objName] || stores[objName].__isRemotedevAction) {
         schedule(objName);
         return;

--- a/src/utils.js
+++ b/src/utils.js
@@ -42,7 +42,7 @@ export const silently = (fn, store) => {
   delete store.__isRemotedevAction;
 };
 
-export const setValue = mobx.action('@@remotedev', (store, state) => {
+function setValueAction(store, state)  {
   silently(() => {
     if (store.importState) {
       store.importState(state);
@@ -53,5 +53,7 @@ export const setValue = mobx.action('@@remotedev', (store, state) => {
     }
   }, store);
   return state;
-});
+}
+setValueAction.__isRemotedevAction = true;
+export const setValue = mobx.action('@@remotedev', setValueAction);
 /* eslint-enable */


### PR DESCRIPTION
That's an alternative to #3.

Very simple: use config to set a `global: true` which marks the store as default store for any uknown changes that `spy()` detects.

Use that store and it's associated `remotedev` to show those changes.