### PR TITLE
Stringify store before sending it to devtools

### DIFF
--- a/src/spy.js
+++ b/src/spy.js
@@ -31,7 +31,13 @@ function init(store, config) {
   stores[name] = store;
 
   const devTools = connectViaExtension(config);
-  devTools.subscribe(dispatchMonitorAction(store, devTools, onlyActions[name]));
+  let serializedStore;
+  try {
+    serializedStore = JSON.stringify(store);
+  } catch(jsonStringifyError) {
+    throw new Error('Store strinigy failed. Make sure your store is JSON stringify-able');
+  }
+  devTools.subscribe(dispatchMonitorAction(serializedStore, devTools, onlyActions[name]));
   monitors[name] = devTools;
 }
 


### PR DESCRIPTION
Redux devtools uses structural cloning algorithm which 
does not like some objects like errors. By running  the sore
through JSON.stringify we make sure the store is not going to fail
when Devtools is running it through structural cloning algorithm.
