### PR TITLE
Upgrade compatibility to mobx 4

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,13 +52,13 @@
     "eslint-plugin-jsx-a11y": "^1.5.3",
     "eslint-plugin-react": "^5.2.2",
     "expect": "^1.20.1",
-    "mobx": "^3.1.2",
+    "mobx": "^4.1.1",
     "mocha": "^2.5.3",
     "rimraf": "^2.5.2",
     "webpack": "^1.13.1"
   },
   "peerDependencies": {
-    "mobx": ">=2.3.0"
+    "mobx": ">=4.0.0"
   },
   "npmName": "mobx-remotedev",
   "npmFileMap": [

--- a/src/spy.js
+++ b/src/spy.js
@@ -26,7 +26,7 @@ function configure(name, config = {}) {
 }
 
 function init(store, config) {
-  const name = mobx.extras.getDebugName(store);
+  const name = mobx.getDebugName(store);
   configure(name, config);
   stores[name] = store;
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -30,7 +30,7 @@ export function createAction(name, change) {
 
 export function getName(obj) {
   if (!obj || !mobx.isObservable(obj)) return '';
-  let r = mobx.extras.getDebugName(obj);
+  let r = mobx.getDebugName(obj);
   let end = r.indexOf('.');
   if (end === -1) end = undefined;
   return r.substr(0, end);


### PR DESCRIPTION
Updates the breaking changes to mobx 4, this seems to just be a case of removing `.extras` as they’ve been moved to the top level. (https://github.com/mobxjs/mobx/wiki/Migrating-from-mobx-3-to-mobx-4#things-that-just-have-moved)
Good thing is this doesn't seem to require any usage changes, but it does mean it's not compatible with mobx < 4.