### PR TITLE
Removed thrown error when global state is already defined

### DIFF
--- a/src/spy.js
+++ b/src/spy.js
@@ -20,8 +20,7 @@ function configure(name, config = {}) {
   }
   if (config.filters) filters[name] = config.filters;
   if (config.global) {
-    if (fallbackStoreName) throw Error('You\'ve already defined a global store');
-    fallbackStoreName = name;
+    fallbackStoreName = fallbackStoreName || name
   }
 }
 


### PR DESCRIPTION
Removed thrown error when global state is already defined, especially for cases with HMR

<img width="975" alt="screen shot 2019-02-21 at 12 03 06 am" src="https://user-images.githubusercontent.com/8204154/53145709-3ba7b780-356f-11e9-952e-ad5210a5df52.png">
